### PR TITLE
Add support for Bonjour, ICQ, and XMPP (Jabber)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,9 @@ RUN set -x \
 	libotr-dev \
 	libgcrypt-dev \
 	libpurple \
+	libpurple-bonjour \
+	libpurple-oscar \
+	libpurple-xmpp \
 	libwebp-dev \
 	pidgin-dev \
     && cd /root \


### PR DESCRIPTION
By default bitlbee compiles agaist libpurple for jabber when
`--purple=1` is used.

This'll enable ICQ, Bonjour, and XMPP (Jabber).